### PR TITLE
Add escape, quote and some tests

### DIFF
--- a/mrblib/mruby_hs_regexp.rb
+++ b/mrblib/mruby_hs_regexp.rb
@@ -13,8 +13,8 @@ class HsRegexp
   }
 
   # ISO 15.2.15.6.1
-  def self.compile(*args)
-    self.new(*args)
+  class << self
+    alias :compile :new
   end
 
   # ISO 15.2.15.6.2
@@ -29,7 +29,7 @@ class HsRegexp
     alias :quote :escape
   end
 
-  # 15.2.15.6.3
+  # ISO 15.2.15.6.3
   def self.last_match
     return @last_match
   end

--- a/mrblib/mruby_hs_regexp.rb
+++ b/mrblib/mruby_hs_regexp.rb
@@ -1,24 +1,55 @@
 class HsRegexp
+  ESCAPE_LIST = {
+    '0x0a' => '\n', '0x09' => '\t',
+    '0x0d' => '\r', '0x0c' => '\f',
+    '0x20' => '\0x20', '#' => '\#',
+    '$' => '\$', '(' => '\(',
+    ')' => '\)', '*' => '\*',
+    '+' => '\+', '-' => '\-',
+    '.' => '\.', '?' => '\?',
+    '[' => '\[', '}' => '\}',
+    ']' => '\]', '^' => '\^',
+    '{' => '\{', '|' => '\|'
+  }
+
   # ISO 15.2.15.6.1
   def self.compile(*args)
     self.new(*args)
   end
 
-  # ISO 15.2.15.7.8
-  attr_reader :source
+  # ISO 15.2.15.6.2
+  def self.escape(str)
+    tmp = str.gsub '\\', '\\\\'
+    ESCAPE_LIST.each { |k, v| tmp = tmp.gsub(k, v) }
+    tmp
+  end
 
+  # ISO 15.2.15.6.4
+  class << self
+    alias :quote :escape
+  end
+
+  # 15.2.15.6.3
   def self.last_match
     return @last_match
   end
 
+  # ISO 15.2.15.7.8
+  attr_reader :source
+
+  # ISO 15.2.15.7.4
   def ===(str)
     return self.match(str) ? true : false
   end
 
+  # ISO 15.2.15.7.5
   def =~(str)
     m = self.match(str)
     return m ? m.begin(0) : nil
   end
+
+  # ISO 15.2.15.7.8
+  attr_reader :source
 end
 
 class HsMatchData
@@ -38,6 +69,12 @@ class HsMatchData
     end
   end
 
+  # ISO 15.2.16.3.1
+  def [](index)
+    d = @data[index]
+    return (d && @string.slice(d[:beg], d[:len]))
+  end
+
   # ISO 15.2.16.3.2
   def begin(index)
     d = @data[index]
@@ -50,10 +87,10 @@ class HsMatchData
     return (d && (d[:beg] + d[:len]))
   end
 
-  # ISO 15.2.16.3.1
-  def [](index)
+  # ISO 15.2.16.3.7
+  def offset(index)
     d = @data[index]
-    return (d && @string.slice(d[:beg], d[:len]))
+    return (d && [ d[:beg], d[:beg] + d[:len] ])
   end
 
   # ISO 15.2.16.3.8
@@ -67,15 +104,8 @@ class HsMatchData
     return @string.slice(0, @data[0][:beg])
   end
 
-  # ISO 15.2.16.3.7
-  def offset(index)
-    d = @data[index]
-    return (d && [ d[:beg], d[:beg] + d[:len] ])
-  end
-
   # ISO 15.2.16.3.13
   def to_s
     return self[0]
   end
 end
-

--- a/test/mruby_hs_regexp.rb
+++ b/test/mruby_hs_regexp.rb
@@ -1,17 +1,33 @@
-
 # Constant
-assert("HsRegexp::CONSTANT") do
+assert('HsRegexp::CONSTANT', '15.2.15.3') do
   HsRegexp::IGNORECASE == 1 and HsRegexp::MULTILINE == 2
 end
 
-
 # Class method
-assert("HsRegexp.new") do
+assert('HsRegexp.new', '15.2.15.6.1') do
   HsRegexp.new(".*") and HsRegexp.new(".*", HsRegexp::MULTILINE)
 end
 
+assert('HsRegexp.compile', '15.2.15.6.1') do
+  HsRegexp.compile(".*") and HsRegexp.compile(".*", HsRegexp::MULTILINE)
+end
+
+assert('HsRegexp.escape', '15.2.15.6.2') do
+  s1 = '#$()*+?'
+  s2 = '\#\$\(\)\*\+\?'
+
+  HsRegexp.escape(s1) == s2
+end
+
+assert('HsRegexp.quote', '15.2.15.6.4') do
+  s1 = '#$()*+?'
+  s2 = '\#\$\(\)\*\+\?'
+
+  HsRegexp.quote(s1) == s2
+end
+
 # Instance method
-assert("HsRegexp#==") do
+assert('HsRegexp#==', '15.2.15.7.3') do
   reg1 = reg2 = HsRegexp.new("(https?://[^/]+)[-a-zA-Z0-9./]+")
   reg3 = HsRegexp.new("(https?://[^/]+)[-a-zA-Z0-9./]+")
   reg4 = HsRegexp.new("(https://[^/]+)[-a-zA-Z0-9./]+")
@@ -19,14 +35,20 @@ assert("HsRegexp#==") do
   reg1 == reg2 and reg1 == reg3 and !(reg1 == reg4)
 end
 
-assert("HsRegexp#===") do
+assert('HsRegexp#===', '15.2.15.7.4') do
   reg = HsRegexp.new("(https?://[^/]+)[-a-zA-Z0-9./]+")
   (reg === "http://example.com") == true and (reg === "htt://example.com") == false
 end
 
-# TODO =~
+assert('HsRegexp#=~', '15.2.15.7.5') do
+  m1 = HsRegexp.new('abc') =~ 'abc'
+  m2 = HsRegexp.new('abc') =~ '1234abc'
+  m3 = HsRegexp.new('abc') =~ '1234'
 
-assert("HsRegexp#casefold?") do
+  m1 == 0 and m2 == 4 and m3.nil?
+end
+
+assert('HsRegexp#casefold?', '15.2.15.7.6') do
   reg1 = HsRegexp.new("(https?://[^/]+)[-a-zA-Z0-9./]+", HsRegexp::MULTILINE)
   reg2 = HsRegexp.new("(https?://[^/]+)[-a-zA-Z0-9./]+", HsRegexp::IGNORECASE)
   reg3 = HsRegexp.new("(https?://[^/]+)[-a-zA-Z0-9./]+", HsRegexp::MULTILINE | HsRegexp::IGNORECASE)
@@ -37,13 +59,13 @@ assert("HsRegexp#casefold?") do
     reg4.casefold? == false and reg5.casefold? == true
 end
 
-assert("HsRegexp#match") do
+assert('HsRegexp#match', '15.2.15.7.7') do
   reg = HsRegexp.new("(https?://[^/]+)[-a-zA-Z0-9./]+")
   reg.match("http://masamitsu-murase.12345/hoge.html") and
     reg.match("http:///masamitsu-murase.12345/hoge.html").nil?
 end
 
-assert("HsRegexp#source") do
+assert('HsRegexp#source', '15.2.15.7.8') do
   str = "(https?://[^/]+)[-a-zA-Z0-9./]+"
   reg = HsRegexp.new(str)
 
@@ -79,4 +101,3 @@ assert("HsRegexp#match (ignorecase)") do
 
   patterns.all?{ |reg, str, result| reg.match(str)[0] == result }
 end
-


### PR DESCRIPTION
This pull request:
- adds method HsRegexp#escape and HsRegexp#quote
- adds tests for these two new methods
- improves tests for existing methods
- adds test for HsRegexp#=~
- simplifies aliasing of HsRegexp#compile
