### PR TITLE
Change mrb_get_args parameter len type to mrb_int

### DIFF
--- a/src/mruby_hs_regexp.c
+++ b/src/mruby_hs_regexp.c
@@ -66,7 +66,7 @@ static mrb_value
 hs_regexp_initialize(mrb_state *mrb, mrb_value self)
 {
     char *str;
-    int len;
+    mrb_int len;
     mrb_value source, flag_value;
     unsigned char flag;
 


### PR DESCRIPTION
mrb_get_args requires int parameters as mrb_int.
But mruby-hs-regexp passes int, so it causes crash if sizeof(int) != sizeof(mrb_int).
Passing mrb_int fixes this.
